### PR TITLE
chore(deps-dev): bump prettier to 2.0.2

### DIFF
--- a/cdk/hitcounter.ts
+++ b/cdk/hitcounter.ts
@@ -15,7 +15,7 @@ export class HitCounter extends cdk.Construct {
     super(scope, id);
 
     const table = new dynamodb.Table(this, "Hits", {
-      partitionKey: { name: "path", type: dynamodb.AttributeType.STRING }
+      partitionKey: { name: "path", type: dynamodb.AttributeType.STRING },
     });
 
     this.handler = new lambda.Function(this, "HitCounterHandler", {
@@ -24,8 +24,8 @@ export class HitCounter extends cdk.Construct {
       code: lambda.Code.fromAsset("dist/lambda"),
       environment: {
         DOWNSTREAM_FUNCTION_NAME: props.downstream.functionName,
-        HITS_TABLE_NAME: table.tableName
-      }
+        HITS_TABLE_NAME: table.tableName,
+      },
     });
 
     // grant the lambda role read/write permissions to our table

--- a/cdk/test-stack.ts
+++ b/cdk/test-stack.ts
@@ -10,15 +10,15 @@ export class TestStack extends cdk.Stack {
     const hello = new lambda.Function(this, "HelloHandler", {
       runtime: lambda.Runtime.NODEJS_12_X,
       code: lambda.Code.fromAsset("dist/lambda"),
-      handler: "hello.handler"
+      handler: "hello.handler",
     });
 
     const helloWithCounter = new HitCounter(this, "HelloHitCounter", {
-      downstream: hello
+      downstream: hello,
     });
 
     new apigw.LambdaRestApi(this, "Endpoint", {
-      handler: helloWithCounter.handler
+      handler: helloWithCounter.handler,
     });
   }
 }

--- a/jest.config.js
+++ b/jest.config.js
@@ -2,6 +2,6 @@ module.exports = {
   roots: ["<rootDir>/src"],
   testMatch: ["**/*.spec.ts"],
   transform: {
-    "^.+\\.tsx?$": "ts-jest"
-  }
+    "^.+\\.tsx?$": "ts-jest",
+  },
 };

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "husky": ">=4",
     "jest": "^25.1.0",
     "lint-staged": ">=10",
-    "prettier": "1.19.1",
+    "prettier": "2.0.2",
     "ts-jest": "^25.2.1",
     "ts-node": "^8.1.0",
     "typescript": "~3.8.3"

--- a/src/lambda/hello.spec.ts
+++ b/src/lambda/hello.spec.ts
@@ -16,9 +16,7 @@ describe("hello lambda:", () => {
   });
 
   it("returns event.path in the body", async () => {
-    mockEvent.path = `/${Math.random()
-      .toString(36)
-      .substring(2)}`;
+    mockEvent.path = `/${Math.random().toString(36).substring(2)}`;
     const response = await handler(mockEvent);
     expect(response.body).toBe(`Hello, CDK! You've hit ${mockEvent.path}\n`);
   });

--- a/src/lambda/hello.ts
+++ b/src/lambda/hello.ts
@@ -1,11 +1,11 @@
 import { APIGatewayEvent } from "aws-lambda";
 
-const handler = async function(event: APIGatewayEvent) {
+const handler = async function (event: APIGatewayEvent) {
   console.log("request:", JSON.stringify(event, undefined, 2));
   return {
     statusCode: 200,
     headers: { "Content-Type": "text/plain" },
-    body: `Hello, CDK! You've hit ${event.path}\n`
+    body: `Hello, CDK! You've hit ${event.path}\n`,
   };
 };
 

--- a/src/lambda/hitcounter.ts
+++ b/src/lambda/hitcounter.ts
@@ -15,7 +15,7 @@ const handler = async (event: APIGatewayEvent) => {
       TableName: process.env.HITS_TABLE_NAME,
       Key: { path: { S: event.path } },
       UpdateExpression: "ADD hits :incr",
-      ExpressionAttributeValues: { ":incr": { N: "1" } }
+      ExpressionAttributeValues: { ":incr": { N: "1" } },
     })
     .promise();
 
@@ -24,7 +24,7 @@ const handler = async (event: APIGatewayEvent) => {
   const resp = await lambda
     .invoke({
       FunctionName: process.env.DOWNSTREAM_FUNCTION_NAME,
-      Payload: JSON.stringify(event)
+      Payload: JSON.stringify(event),
     })
     .promise();
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3927,10 +3927,10 @@ prelude-ls@~1.1.2:
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.1.2.tgz#21932a549f5e52ffd9a827f570e04be62a97da54"
   integrity sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=
 
-prettier@1.19.1:
-  version "1.19.1"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.19.1.tgz#f7d7f5ff8a9cd872a7be4ca142095956a60797cb"
-  integrity sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==
+prettier@2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.0.2.tgz#1ba8f3eb92231e769b7fcd7cb73ae1b6b74ade08"
+  integrity sha512-5xJQIPT8BraI7ZnaDwSbu5zLrB6vvi8hVV58yHQ+QK64qrY40dULy0HSRlQ2/2IdzeBpjhDkqdcFBnFeDEMVdg==
 
 pretty-format@^25.1.0:
   version "25.1.0"


### PR DESCRIPTION
Refs: prettier-vscode@4.0.0 is not backward-compatible
https://github.com/prettier/prettier-vscode/issues/1290